### PR TITLE
Make main screen the default, redirect to login if needed (close #28)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="pl.pwr.zpi.bcycle.mobile">
-    
+
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
@@ -13,18 +13,18 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".RegisterActivity"></activity>
-        <activity android:name=".LoginActivity">
+        <activity android:name=".RegisterActivity" />
+        <activity android:name=".LoginActivity" />
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/pl/pwr/zpi/bcycle/mobile/LoginActivity.kt
+++ b/app/src/main/java/pl/pwr/zpi/bcycle/mobile/LoginActivity.kt
@@ -18,10 +18,6 @@ class LoginActivity : AppCompatActivity() {
 
         supportActionBar?.hide()
 
-        if(auth.currentUser != null){
-            startActivity(Intent(this, MainActivity::class.java))
-        }
-
         loginBt.setOnClickListener {
             if (isFormFilled()) signIn() else showToast("Enter both email and password")
         }
@@ -38,6 +34,7 @@ class LoginActivity : AppCompatActivity() {
         auth.signInWithEmailAndPassword(email.content(), password.content())
             .addOnSuccessListener {
                 startActivity(Intent(this, MainActivity::class.java))
+                finish()
             }.addOnFailureListener {
                 showToast("Failed to sign in: ${it.localizedMessage}")
             }

--- a/app/src/main/java/pl/pwr/zpi/bcycle/mobile/MainActivity.kt
+++ b/app/src/main/java/pl/pwr/zpi/bcycle/mobile/MainActivity.kt
@@ -1,5 +1,6 @@
 package pl.pwr.zpi.bcycle.mobile
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -65,7 +66,12 @@ class MainActivity : AppCompatActivity() {
             storage.getReferenceFromUrl(this.photoUrl.toString()).downloadUrl
                 .addOnSuccessListener{ Picasso.get().load(it).into(header.currentUserImage) }
 
-        } ?: finish()
+        } ?: openLoginScreen()
+    }
+
+    private fun openLoginScreen() {
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
The home screen activity should be the one that’s important to users. LoginActivity should appear only in an error condition (user misisng).